### PR TITLE
warmup関数のパラメータ名を修正

### DIFF
--- a/function_app.py
+++ b/function_app.py
@@ -179,7 +179,7 @@ def http_trigger(req: func.HttpRequest) -> func.HttpResponse:
 
 
 @app.route(route="warmup")
-def warmup(_: func.HttpRequest) -> func.HttpResponse:
+def warmup(req: func.HttpRequest) -> func.HttpResponse:
     """
     コールドスタート対策用のウォームアップ関数
     定期的に呼び出すことでFunction Appのインスタンスを温かく保つ


### PR DESCRIPTION
Azure Functionsのfunction.jsonとの互換性を保つため
パラメータ名を'_'から'req'に変更

🤖 Generated with [Claude Code](https://claude.ai/code)